### PR TITLE
Feature: remove netlify for Cloudflare Pages

### DIFF
--- a/.github/workflows/imgcmp.yml
+++ b/.github/workflows/imgcmp.yml
@@ -1,0 +1,9 @@
+name: Image Optimization
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest    
+    steps:
+    - uses: 9sako6/imgcmp@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-venclave.com
-============
 
-This is the repository that builds the static website for [venclave.com](https://venclave.com/) using [hugo](https://gohugo.io/).
+# ironpeak.be
 
-Current build status:
-[![Netlify Status](https://api.netlify.com/api/v1/badges/620e02cd-7598-4e31-9f82-afde33c232b4/deploy-status)](https://app.netlify.com/sites/naughty-roentgen-93834e/deploys)
+This is the repository that builds the static website for [venclave.com](https://venclave.com/) using [hugo](https://gohugo.io/) and deploys to [Cloudflare Pages](https://pages.cloudflare.com).
 
-CI / CD
--------
-The pipeline runs on a free instance of [Netlify](https://www.netlify.com/), since this supports setting security headers compared to Github Pages.
+## Slides
 
-Building
---------
-`hugo server` to run locally, `hugo --gc --minify` to build minified output to `generated/`.
+If you are looking for the presentation slides I gave somewhere, look in the [static/slides/](static/slides/) directory.
+
+## Building
+
+With `hugo` installed, you can use `make build` for production builds and `make dev` for local development.


### PR DESCRIPTION
We're using Cloudflare caching anyway, better to just use their CDN.